### PR TITLE
词组查询功能, 用正则过滤掉用户输入的非法字符

### DIFF
--- a/ici/ici.py
+++ b/ici/ici.py
@@ -7,6 +7,7 @@ from xml.dom import minidom
 
 from termcolor import colored
 
+import re
 
 KEY = 'E0F0D336AF47D3797C68372A869BDBC5'
 URL = 'http://dict-co.iciba.com/api/dictionary.php'
@@ -28,6 +29,8 @@ def show(node):
             content = node.data.replace('\n', '')
             if tag_name == 'ps':
                 print colored('[' + content + ']', 'green')
+            if tag_name == 'fy':
+                print colored(content, 'green')
             if tag_name == 'orig':
                 print colored('ex. ' + content, 'blue')
             if tag_name == 'trans':
@@ -47,7 +50,8 @@ def main():
     except getopt.GetoptError as e:
         pass
 
-    word = " ".join(args).lower()
+    match = re.findall(r'[\w.]+', " ".join(args).lower())
+    word = "_".join(match)
     root = read_xml(get_response(word))
     show(root)
 


### PR DESCRIPTION
首先感谢,很有趣的项目,在我的ubuntu上跑起来太棒了.
但是我发现不支持*词组*的查询,于是做了下修改. 并且用正则表达式过滤掉用户输入一些非法的字符,比如*逗号,括号*什么的,效果如下图所示
![screenshot from 2015-05-14 16 40 33](https://cloud.githubusercontent.com/assets/7122066/7628644/76792a34-fa58-11e4-9ed0-61d9ea6ed5cc.png)
